### PR TITLE
Make Wi-Fi Spoofing show up in receiver apps

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -21,6 +21,9 @@ Note that CLI flags override config values.
 - `ble` (object): BLE-specific settings (optional).
   - `adapter` (string): HCI adapter name. Default: `"hci0"`.
   - `advertising_interval_ms` (int): time per BLE advertisement in ms. Default: `200`.
+- `wifi` (object): Wi-Fi-specific settings (optional).
+  - `channel` (int): Wi-Fi channel for injection. Default: `6`.
+  - `ess` (bool): Set ESS capability (make beacon look like an AP). Default: `false`.
 
 ## Drone fields
 Each entry in `drones` describes a single drone. Missing fields are generated

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -24,6 +24,7 @@ Note that CLI flags override config values.
 - `wifi` (object): Wi-Fi-specific settings (optional).
   - `channel` (int): Wi-Fi channel for injection. Default: `6`.
   - `ess` (bool): Set ESS capability (make beacon look like an AP). Default: `false`.
+  - `beacon_interval` (number): Wi-Fi beacon transmission interval in seconds. Default: `0.1024`.
 
 ## Drone fields
 Each entry in `drones` describes a single drone. Missing fields are generated

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -32,7 +32,10 @@ randomly (serial, MAC, and locations).
 
 - `mode` (string): `"random"`, `"static"`, or `"waypoints"`. Default: `"random"`.
 - `serial` (string): max 20 chars. Optional.
-- `mac` (string): MAC address. Optional.
+- `mac` (string): Wi-Fi source MAC address. Must be a **unicast, locally-administered** address
+  (byte[0] bits: `0bxxxxxx10`). Randomly generated if omitted. Optional.
+- `ble_mac` (string): BLE advertiser address. Must be a **Static Random** address per BT Core Spec §1.3.2
+  (byte[0] bits: `0b11xxxxxx`). Randomly generated if omitted. Optional.
 - `start_location` ([lat, lng]): initial drone location. Optional.
 - `pilot_location` ([lat, lng]): pilot position. Optional.
 - `lifespan_seconds` (int): stop transmitting after N seconds. Optional.

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ For full architecture details, see [ARCHITECTURE.md](ARCHITECTURE.md).
 | | `--ble-adapter` | `str` | config or `hci0` | BLE HCI adapter name |
 | | `--wifi-channel`| `int` | config or `6` | Wi-Fi channel for injection |
 | | `--wifi-ess`    | - | - | Set ESS capability (make beacon look like an AP) |
+| | `--wifi-beacon-interval` | `float` | config or `0.1024` | Wi-Fi beacon transmission interval in seconds |
 
 CLI flags override values from scenario config files.
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ For full architecture details, see [ARCHITECTURE.md](ARCHITECTURE.md).
 | `-v` | `--verbose` | - | - | Enable debug logging |
 | `-t` | `--transport` | `wifi\|ble\|both` | config or `wifi` | Transport backend |
 | | `--ble-adapter` | `str` | config or `hci0` | BLE HCI adapter name |
+| | `--wifi-channel`| `int` | config or `6` | Wi-Fi channel for injection |
+| | `--wifi-ess`    | - | - | Set ESS capability (make beacon look like an AP) |
 
 CLI flags override values from scenario config files.
 

--- a/drone_rid_spoofer/cli.py
+++ b/drone_rid_spoofer/cli.py
@@ -58,6 +58,10 @@ def parse_args() -> argparse.Namespace:
                              "(default: off; spoofed drone is not advertised as an AP)")
     parser.add_argument("--wifi-channel", type=int, default=None,
                         help="Wi-Fi channel to broadcast on (default: 6)")
+    parser.add_argument("--wifi-beacon-interval", type=float, default=None,
+                        help="Wi-Fi beacon transmission interval in seconds. "
+                             "ASTM F3411-22 requires <0.2s (200 TUs) on most channels. "
+                             "Social channels (6, 149) have more lax requirements. (default: 0.1024)")
 
     args = parser.parse_args()
 
@@ -78,13 +82,13 @@ def load_config(path: str) -> dict:
 
 def create_backends(transport: str, interface: str, ble_adapter: str,
                     ble_interval_ms: int, wifi_ess: bool = False,
-                    wifi_channel: int = 6) -> List[TransportBackend]:
+                    wifi_channel: int = 6, wifi_beacon_interval: float = 0.1024) -> List[TransportBackend]:
     """Create transport backend instances based on configuration."""
     backends: List[TransportBackend] = []
 
     if transport in ("wifi", "both"):
         from drone_rid_spoofer.transport.wifi import WifiBackend
-        backends.append(WifiBackend(interface, ess=wifi_ess, channel=wifi_channel))
+        backends.append(WifiBackend(interface, ess=wifi_ess, channel=wifi_channel, beacon_interval=wifi_beacon_interval))
 
     if transport in ("ble", "both"):
         from drone_rid_spoofer.transport.ble import BleBackend
@@ -137,6 +141,10 @@ def main() -> None:
         if getattr(args, 'wifi_channel', None) is None:
             wifi_config = config_global.get("wifi", {})
             args.wifi_channel = int(wifi_config.get("channel", 6))
+            
+        if getattr(args, 'wifi_beacon_interval', None) is None:
+            wifi_config = config_global.get("wifi", {})
+            args.wifi_beacon_interval = float(wifi_config.get("beacon_interval", 0.1024))
 
         if args.random < 1:
             raise ValueError("Number of random drones must be at least 1")
@@ -148,7 +156,8 @@ def main() -> None:
 
         backends = create_backends(args.transport, args.interface, args.ble_adapter,
                                    ble_interval_ms, wifi_ess=args.wifi_ess,
-                                   wifi_channel=args.wifi_channel)
+                                   wifi_channel=args.wifi_channel,
+                                   wifi_beacon_interval=args.wifi_beacon_interval)
         spoofer = DroneSpoofer(args, backends)
 
         try:

--- a/drone_rid_spoofer/cli.py
+++ b/drone_rid_spoofer/cli.py
@@ -56,6 +56,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--wifi-ess", action="store_true", default=None,
                         help="Set the ESS capability bit on Wi-Fi beacons "
                              "(default: off; spoofed drone is not advertised as an AP)")
+    parser.add_argument("--wifi-channel", type=int, default=None,
+                        help="Wi-Fi channel to broadcast on (default: 6)")
 
     args = parser.parse_args()
 
@@ -75,13 +77,14 @@ def load_config(path: str) -> dict:
 
 
 def create_backends(transport: str, interface: str, ble_adapter: str,
-                    ble_interval_ms: int, wifi_ess: bool = False) -> List[TransportBackend]:
+                    ble_interval_ms: int, wifi_ess: bool = False,
+                    wifi_channel: int = 6) -> List[TransportBackend]:
     """Create transport backend instances based on configuration."""
     backends: List[TransportBackend] = []
 
     if transport in ("wifi", "both"):
         from drone_rid_spoofer.transport.wifi import WifiBackend
-        backends.append(WifiBackend(interface, ess=wifi_ess))
+        backends.append(WifiBackend(interface, ess=wifi_ess, channel=wifi_channel))
 
     if transport in ("ble", "both"):
         from drone_rid_spoofer.transport.ble import BleBackend
@@ -130,6 +133,10 @@ def main() -> None:
         if args.wifi_ess is None:
             wifi_config = config_global.get("wifi", {})
             args.wifi_ess = bool(wifi_config.get("ess", False))
+            
+        if getattr(args, 'wifi_channel', None) is None:
+            wifi_config = config_global.get("wifi", {})
+            args.wifi_channel = int(wifi_config.get("channel", 6))
 
         if args.random < 1:
             raise ValueError("Number of random drones must be at least 1")
@@ -140,7 +147,8 @@ def main() -> None:
         logging.info(f"Interval between packets(s): {args.interval}s")
 
         backends = create_backends(args.transport, args.interface, args.ble_adapter,
-                                   ble_interval_ms, wifi_ess=args.wifi_ess)
+                                   ble_interval_ms, wifi_ess=args.wifi_ess,
+                                   wifi_channel=args.wifi_channel)
         spoofer = DroneSpoofer(args, backends)
 
         try:

--- a/drone_rid_spoofer/helpers.py
+++ b/drone_rid_spoofer/helpers.py
@@ -27,15 +27,32 @@ def parse_location(latitude: str, longitude: str) -> Tuple[int, int]:
     return int(lat * 10**7), int(lng * 10**7)
 
 
-def generate_random_mac() -> str:
-    """Generate a random MAC address.
+def generate_wifi_mac() -> str:
+    """Generate a random locally-administered unicast MAC for Wi-Fi injection.
 
-    Top 2 bits of the MSB are forced to 11 so the address qualifies as a BLE
-    Static Random Address (BT Core). Without this, controllers reject ~25% of
-    fully-random MACs and treat others as RPA/NRPA, breaking BLE advertising.
+    Bit semantics of byte[0]:
+      - bit 0 (multicast): forced to 0 → unicast; the 802.11 stack rejects
+        multicast source addresses at the driver level.
+      - bit 1 (locally-administered): forced to 1 → LAA; signals to receivers
+        that this is a spoofed/virtual address, not a burned-in OUI.
+    Result mask: 0bxxxxxx10
     """
     parts = [random.randint(0, 255) for _ in range(6)]
-    parts[0] |= 0xC0
+    parts[0] = (parts[0] & 0xFC) | 0x02  # clear multicast, set locally-administered
+    return ":".join(f"{b:02x}" for b in parts)
+
+
+def generate_ble_mac() -> str:
+    """Generate a random Static Random Address for BLE advertising.
+
+    The Bluetooth Core Specification (Vol 6, Part B, §1.3.2) requires the two
+    most significant bits of byte[0] to be 0b11 for a Static Random Address.
+    Without this, HCI controllers classify the address as Resolvable or
+    Non-Resolvable Private, and ~25 % of random MACs are outright rejected.
+    Result mask: 0b11xxxxxx
+    """
+    parts = [random.randint(0, 255) for _ in range(6)]
+    parts[0] |= 0xC0  # force top 2 bits to 11
     return ":".join(f"{b:02x}" for b in parts)
 
 

--- a/drone_rid_spoofer/messages.py
+++ b/drone_rid_spoofer/messages.py
@@ -1,8 +1,18 @@
 import struct
 from datetime import datetime, timedelta
+from enum import IntEnum
 from typing import Tuple, List
 
 from drone_rid_spoofer.state import DroneState
+
+class MsgType(IntEnum):
+    BASIC_ID = 0x0
+    LOCATION = 0x1
+    AUTH = 0x2
+    SELF_ID = 0x3
+    SYSTEM = 0x4
+    OPERATOR_ID = 0x5
+    PACK = 0xF
 
 SELF_ID_DESCRIPTION = b"Spoofing test"
 
@@ -31,10 +41,11 @@ def _encode_altitude(alt_m: float) -> int:
     return max(0, min(0xFFFF, int(round((alt_m + 1000.0) * 2))))
 
 
-def build_basic_id(serial: bytes) -> bytes:
+def build_basic_id(serial: bytes, protocol_version: int = 2) -> bytes:
     """Build Message Type 0 - Basic ID (25 bytes)."""
     serial_packed = struct.pack("<20s", serial)
-    return b'\x00\x12' + serial_packed + b'\x00\x00\x00'
+    header = bytes([(MsgType.BASIC_ID << 4) | protocol_version, 0x12])
+    return header + serial_packed + b'\x00\x00\x00'
 
 
 def build_location_vector(lat: int, lng: int, direction: int,
@@ -43,7 +54,8 @@ def build_location_vector(lat: int, lng: int, direction: int,
                           pressure_altitude: float = 0.0,
                           geodetic_altitude: float = 0.0,
                           height: float = 0.0,
-                          timestamp_offset: float = 0.0) -> bytes:
+                          timestamp_offset: float = 0.0,
+                          protocol_version: int = 2) -> bytes:
     """Build Message Type 1 - Location/Vector (25 bytes).
 
     Args:
@@ -56,7 +68,7 @@ def build_location_vector(lat: int, lng: int, direction: int,
     tenth_seconds = (now.minute * 600 + now.second * 10) % 6000
 
     return b''.join([
-        struct.pack("<B", 0x10),
+        struct.pack("<B", (MsgType.LOCATION << 4) | protocol_version),
         struct.pack("<B", ew_dir),
         struct.pack("<B", dir_val),
         struct.pack("<B", _encode_speed(speed)),
@@ -72,10 +84,10 @@ def build_location_vector(lat: int, lng: int, direction: int,
     ])
 
 
-def build_system(pilot_lat: int, pilot_lng: int) -> bytes:
+def build_system(pilot_lat: int, pilot_lng: int, protocol_version: int = 2) -> bytes:
     """Build Message Type 4 - System (25 bytes)."""
     return b''.join([
-        struct.pack("<B", 0x40),
+        struct.pack("<B", (MsgType.SYSTEM << 4) | protocol_version),
         struct.pack("<B", 0x05),
         struct.pack("<i", pilot_lat),
         struct.pack("<i", pilot_lng),
@@ -85,24 +97,25 @@ def build_system(pilot_lat: int, pilot_lng: int) -> bytes:
     ])
 
 
-def build_self_id(description: bytes = SELF_ID_DESCRIPTION) -> bytes:
+def build_self_id(description: bytes = SELF_ID_DESCRIPTION, protocol_version: int = 2) -> bytes:
     """Build Message Type 3 - Self ID (25 bytes).
 
     Description type 0x00 = text. Body is 23 ASCII bytes (null-padded).
     """
     body = description[:23].ljust(23, b'\x00')
-    return b'\x30\x00' + body
+    header = bytes([(MsgType.SELF_ID << 4) | protocol_version, 0x00])
+    return header + body
 
 
-def build_operator_id() -> bytes:
+def build_operator_id(protocol_version: int = 2) -> bytes:
     """Build Message Type 5 - Operator ID (25 bytes)."""
-    return b'\x50' + b'\x00' * 24
+    return bytes([(MsgType.OPERATOR_ID << 4) | protocol_version]) + b'\x00' * 24
 
 
-def build_all_messages(drone: DroneState) -> List[bytes]:
+def build_all_messages(drone: DroneState, protocol_version: int = 2) -> List[bytes]:
     """Build all ASTM message payloads for a drone."""
     return [
-        build_basic_id(drone.serial),
+        build_basic_id(drone.serial, protocol_version=protocol_version),
         build_location_vector(
             drone.lat, drone.lng, drone.direction,
             speed=drone.speed,
@@ -111,8 +124,9 @@ def build_all_messages(drone: DroneState) -> List[bytes]:
             geodetic_altitude=drone.geodetic_altitude,
             height=drone.height,
             timestamp_offset=drone.timestamp_offset,
+            protocol_version=protocol_version
         ),
-        build_self_id(),
-        build_system(drone.pilot_location[0], drone.pilot_location[1]),
-        build_operator_id(),
+        build_self_id(protocol_version=protocol_version),
+        build_system(drone.pilot_location[0], drone.pilot_location[1], protocol_version=protocol_version),
+        build_operator_id(protocol_version=protocol_version),
     ]

--- a/drone_rid_spoofer/spoofer.py
+++ b/drone_rid_spoofer/spoofer.py
@@ -9,7 +9,8 @@ from datetime import datetime, timedelta
 from typing import List, Optional
 
 from drone_rid_spoofer.helpers import (
-    generate_random_mac,
+    generate_ble_mac,
+    generate_wifi_mac,
     get_random_pilot_location,
     get_random_serial_number,
     parse_location,
@@ -52,11 +53,12 @@ class DroneSpoofer:
         serial = self.args.serial.encode() if self.args.serial else get_random_serial_number()
         lat, lng = random_location(*self.args.location, 10000)
         pilot_loc = get_random_pilot_location(lat, lng)
-        mac_addr = generate_random_mac()
+        mac_addr = generate_wifi_mac()
+        ble_addr = generate_ble_mac()
 
-        drone = DroneState(serial, pilot_loc, lat, lng, mac_addr)
+        drone = DroneState(serial, pilot_loc, lat, lng, mac_addr, ble_addr)
         self._seed_kinematics(drone)
-        logger.info(f"Drone {serial.decode()} created at [{lat}, {lng}] with MAC {mac_addr}")
+        logger.info(f"Drone {serial.decode()} created at [{lat}, {lng}] with Wi-Fi MAC {mac_addr}, BLE addr {ble_addr}")
 
         self._run_manual_control_loop(drone)
 
@@ -120,12 +122,13 @@ class DroneSpoofer:
             serial = get_random_serial_number()
             lat, lng = random_location(base_lat, base_lng, 50000)
             pilot_loc = get_random_pilot_location(lat, lng)
-            mac_addr = generate_random_mac()
+            mac_addr = generate_wifi_mac()
+            ble_addr = generate_ble_mac()
 
-            drone = DroneState(serial, pilot_loc, lat, lng, mac_addr)
+            drone = DroneState(serial, pilot_loc, lat, lng, mac_addr, ble_addr)
             self._seed_kinematics(drone)
             drones.append(drone)
-            logger.info(f"Drone {serial.decode()} created with MAC {mac_addr}")
+            logger.info(f"Drone {serial.decode()} created with Wi-Fi MAC {mac_addr}, BLE addr {ble_addr}")
 
         return drones
 
@@ -184,7 +187,8 @@ class DroneSpoofer:
 
             serial = entry.get("serial")
             serial_bytes = serial.encode() if serial else get_random_serial_number()
-            mac_addr = entry.get("mac") or generate_random_mac()
+            mac_addr = entry.get("mac") or generate_wifi_mac()
+            ble_addr = entry.get("ble_mac") or generate_ble_mac()
             lifespan_seconds = entry.get("lifespan_seconds", 0)
             end_time = None
             if lifespan_seconds and lifespan_seconds > 0:
@@ -199,6 +203,7 @@ class DroneSpoofer:
                 lat=lat,
                 lng=lng,
                 mac_address=mac_addr,
+                ble_address=ble_addr,
                 mode=mode,
                 end_time=end_time,
                 waypoints=waypoints,
@@ -207,7 +212,7 @@ class DroneSpoofer:
             )
             self._seed_kinematics(drone, overrides=self._extract_kinematic_overrides(entry))
             drones.append(drone)
-            logger.info(f"Drone {serial_bytes.decode()} created with MAC {mac_addr} mode={mode}")
+            logger.info(f"Drone {serial_bytes.decode()} created with Wi-Fi MAC {mac_addr}, BLE addr {ble_addr} mode={mode}")
 
         return drones
 

--- a/drone_rid_spoofer/state.py
+++ b/drone_rid_spoofer/state.py
@@ -12,7 +12,8 @@ class DroneState:
     pilot_location: Tuple[int, int]
     lat: int
     lng: int
-    mac_address: str
+    mac_address: str       # Wi-Fi unicast LAA
+    ble_address: str        # BLE Static Random
     direction: int = 0
     mode: str = "random"
     end_time: Optional[datetime] = None

--- a/drone_rid_spoofer/transport/ble.py
+++ b/drone_rid_spoofer/transport/ble.py
@@ -273,7 +273,7 @@ class BleBackend(TransportBackend):
         self._set_advertising_enable(False)
 
         # Set random address to drone's MAC
-        self._set_random_address(drone.mac_address)
+        self._set_random_address(drone.ble_address)
         self._set_advertising_params()
 
         send_sequence = self._build_send_sequence(drone_key, messages)

--- a/drone_rid_spoofer/transport/ble.py
+++ b/drone_rid_spoofer/transport/ble.py
@@ -23,6 +23,7 @@ import time
 from typing import Dict, List, Optional
 
 from drone_rid_spoofer.state import DroneState
+from drone_rid_spoofer.messages import MsgType
 from drone_rid_spoofer.transport.base import TransportBackend
 
 logger = logging.getLogger(__name__)
@@ -59,10 +60,7 @@ ASTM_UUID = b'\xFA\xFF'  # 0xFFFA little-endian
 ASTM_APP_CODE = 0x0D
 AD_TYPE_SERVICE_DATA_16 = 0x16
 
-# Location message type byte starts with 0x10
-LOCATION_MSG_PREFIX = 0x10
-
-
+# Location message type is 1 (upper 4 bits)
 def _mac_to_bytes(mac: str) -> bytes:
     """Convert MAC address string to 6 bytes (reverse order for HCI)."""
     parts = mac.split(':')
@@ -246,8 +244,8 @@ class BleBackend(TransportBackend):
         Static messages (BasicID, Self-ID, System, OperatorID) rotate one per
         cycle so each is refreshed every N cycles, where N = number of statics.
         """
-        location_msgs = [m for m in messages if m and m[0] == LOCATION_MSG_PREFIX]
-        static_msgs = [m for m in messages if m and m[0] != LOCATION_MSG_PREFIX]
+        location_msgs = [m for m in messages if m and (m[0] >> 4) == MsgType.LOCATION]
+        static_msgs = [m for m in messages if m and (m[0] >> 4) != MsgType.LOCATION]
 
         sequence = location_msgs * 3
         if static_msgs:

--- a/drone_rid_spoofer/transport/wifi.py
+++ b/drone_rid_spoofer/transport/wifi.py
@@ -1,4 +1,5 @@
 import logging
+import subprocess
 from typing import List
 
 from scapy.all import sendp
@@ -19,12 +20,21 @@ class WifiBackend(TransportBackend):
     SSID_PREFIX = 'RID-'
     SSID_MAX_LEN = 32
     OUI = b'\xfa\x0b\xbc'
-    SUPPORTED_RATES = b'\x82\x84\x8b\x96\x24\x30\x48\x6c'
+    SUPPORTED_RATES = b'\x82\x84\x8b\x96'
+    EXTENDED_SUPPORTED_RATES = b'\x0c\x12\x18\x24\x30\x48\x60\x6c'
 
-    def __init__(self, interface: str, ess: bool = False, protocol_version: int = 2):
+    def __init__(self, interface: str, ess: bool = False, protocol_version: int = 2, channel: int = 6):
         self.interface = interface
         self.ess = ess
         self.protocol_version = protocol_version
+        self.channel = channel
+        
+        # Lock the physical interface to the target channel to ensure compliance
+        try:
+            subprocess.run(["sudo", "iw", "dev", self.interface, "set", "channel", str(self.channel)], check=True)
+            logger.info(f"Wi-Fi interface {self.interface} locked to channel {self.channel}")
+        except subprocess.CalledProcessError as e:
+            logger.warning(f"Could not lock channel on {self.interface}: {e}")
         
         # Message pack header: msg_type (0xF = Pack) + ver, msg_size (0x19 = 25 bytes)
         self.pack_header_prefix = bytes([(MsgType.PACK << 4) | self.protocol_version, 0x19])
@@ -44,6 +54,11 @@ class WifiBackend(TransportBackend):
         ssid = (self.SSID_PREFIX + serial_str)[: self.SSID_MAX_LEN]
         ie_ssid = dot11.Dot11Elt(ID='SSID', info=ssid)
         ie_rates = dot11.Dot11Elt(ID='Rates', info=self.SUPPORTED_RATES)
+        ie_dsset = dot11.Dot11Elt(ID='DSset', info=bytes([self.channel]))
+        ie_tim = dot11.Dot11Elt(ID='TIM', info=b'\x00\x01\x00\x00')
+        ie_erp = dot11.Dot11Elt(ID='ERPinfo', info=b'\x00')
+        ie_esr = dot11.Dot11Elt(ID='ESRates', info=self.EXTENDED_SUPPORTED_RATES)
+
         # Build the vendor-specific IE as raw bytes so the element length
         # covers both the OUI and the Remote ID payload.
         ie_vendor = dot11.Dot11Elt(ID=221, info=self.OUI + vendor_data)
@@ -59,6 +74,10 @@ class WifiBackend(TransportBackend):
             dot11.Dot11Beacon(cap='ESS' if self.ess else 0) /
             ie_ssid /
             ie_rates /
+            ie_dsset /
+            ie_tim /
+            ie_erp /
+            ie_esr /
             ie_vendor
         )
 

--- a/drone_rid_spoofer/transport/wifi.py
+++ b/drone_rid_spoofer/transport/wifi.py
@@ -1,6 +1,8 @@
 import logging
 import subprocess
-from typing import List
+import threading
+import time
+from typing import List, Dict, Tuple
 
 from scapy.all import sendp
 import scapy.layers.dot11 as dot11
@@ -23,11 +25,12 @@ class WifiBackend(TransportBackend):
     SUPPORTED_RATES = b'\x82\x84\x8b\x96'
     EXTENDED_SUPPORTED_RATES = b'\x0c\x12\x18\x24\x30\x48\x60\x6c'
 
-    def __init__(self, interface: str, ess: bool = False, protocol_version: int = 2, channel: int = 6):
+    def __init__(self, interface: str, ess: bool = False, protocol_version: int = 2, channel: int = 6, beacon_interval: float = 0.1024):
         self.interface = interface
         self.ess = ess
         self.protocol_version = protocol_version
         self.channel = channel
+        self.beacon_interval = beacon_interval
         
         # Lock the physical interface to the target channel to ensure compliance
         try:
@@ -42,6 +45,49 @@ class WifiBackend(TransportBackend):
         # ODID message-pack counter: must increment per transmission so
         # receivers treat each beacon as a fresh message rather than a duplicate.
         self._counter = 0
+
+        self._payloads: Dict[bytes, Tuple[dot11.Packet, dot11.Packet, str]] = {}
+        self._seq_nums: Dict[bytes, int] = {}
+        self._lock = threading.Lock()
+        self._running = True
+        self._thread = threading.Thread(target=self._transmit_loop, daemon=True)
+        self._thread.start()
+        logger.info(f"Wi-Fi backend started on {interface} with {self.beacon_interval*1000:.0f}ms beacon interval")
+
+    def _transmit_loop(self) -> None:
+        """Continuously broadcast all active beacons at the specified interval."""
+        while self._running:
+            packets = []
+            current_tsf = int(time.time() * 1000000) % (2**64)
+            
+            with self._lock:
+                items = list(self._payloads.items())
+            
+            for serial, (radiotap, ies, mac_addr) in items:
+                with self._lock:
+                    seq_num = self._seq_nums.get(serial, 0)
+                    self._seq_nums[serial] = (seq_num + 1) % 4096
+                
+                # Dynamically instantiate the header to avoid thread contention on shared Scapy objects
+                dot11_base = dot11.Dot11(
+                    type=0, subtype=8,
+                    addr1=self.DEST_ADDR,
+                    addr2=mac_addr,
+                    addr3=mac_addr,
+                    SC=(seq_num << 4)
+                )
+                beacon_base = dot11.Dot11Beacon(cap='ESS' if self.ess else 0, timestamp=current_tsf)
+                
+                frame = radiotap / dot11_base / beacon_base / ies
+                packets.append(frame)
+                
+            if packets:
+                try:
+                    sendp(packets, iface=self.interface, verbose=False)
+                except Exception as e:
+                    logger.debug(f"Wi-Fi transmit error: {e}")
+                    
+            time.sleep(self.beacon_interval)
 
     def send_messages(self, drone: DroneState, messages: List[bytes]) -> None:
         """Pack all messages into a single Wi-Fi beacon vendor-specific IE and send."""
@@ -63,25 +109,14 @@ class WifiBackend(TransportBackend):
         # covers both the OUI and the Remote ID payload.
         ie_vendor = dot11.Dot11Elt(ID=221, info=self.OUI + vendor_data)
 
-        packet = (
-            dot11.RadioTap() /
-            dot11.Dot11(
-                type=0, subtype=8,
-                addr1=self.DEST_ADDR,
-                addr2=drone.mac_address,
-                addr3=drone.mac_address,
-            ) /
-            dot11.Dot11Beacon(cap='ESS' if self.ess else 0) /
-            ie_ssid /
-            ie_rates /
-            ie_dsset /
-            ie_tim /
-            ie_erp /
-            ie_esr /
-            ie_vendor
-        )
-
-        sendp(packet, iface=self.interface, verbose=False, count=1)
+        radiotap = dot11.RadioTap()
+        ies = ie_ssid / ie_rates / ie_dsset / ie_tim / ie_erp / ie_esr / ie_vendor
+        
+        with self._lock:
+            self._payloads[drone.serial] = (radiotap, ies, drone.mac_address)
 
     def close(self) -> None:
-        pass
+        self._running = False
+        if self._thread.is_alive():
+            self._thread.join(timeout=1.0)
+        logger.info("Wi-Fi backend closed")

--- a/drone_rid_spoofer/transport/wifi.py
+++ b/drone_rid_spoofer/transport/wifi.py
@@ -5,6 +5,7 @@ from scapy.all import sendp
 import scapy.layers.dot11 as dot11
 
 from drone_rid_spoofer.state import DroneState
+from drone_rid_spoofer.messages import MsgType
 from drone_rid_spoofer.transport.base import TransportBackend
 
 logger = logging.getLogger(__name__)
@@ -14,18 +15,20 @@ class WifiBackend(TransportBackend):
     """Wi-Fi beacon frame transport for ASTM F3411-19 RID."""
 
     APP_CODE = 0x0D
-    # Message pack header: msg_type+ver (0xf0 = pack/v0), msg_size (0x19 = 25 bytes)
-    # Followed dynamically by the message count (one byte) per send.
-    PACK_HEADER_PREFIX = b'\xf0\x19'
     DEST_ADDR = 'ff:ff:ff:ff:ff:ff'
     SSID_PREFIX = 'RID-'
     SSID_MAX_LEN = 32
     OUI = b'\xfa\x0b\xbc'
     SUPPORTED_RATES = b'\x82\x84\x8b\x96\x24\x30\x48\x6c'
 
-    def __init__(self, interface: str, ess: bool = False):
+    def __init__(self, interface: str, ess: bool = False, protocol_version: int = 2):
         self.interface = interface
         self.ess = ess
+        self.protocol_version = protocol_version
+        
+        # Message pack header: msg_type (0xF = Pack) + ver, msg_size (0x19 = 25 bytes)
+        self.pack_header_prefix = bytes([(MsgType.PACK << 4) | self.protocol_version, 0x19])
+        
         # ODID message-pack counter: must increment per transmission so
         # receivers treat each beacon as a fresh message rather than a duplicate.
         self._counter = 0
@@ -33,7 +36,7 @@ class WifiBackend(TransportBackend):
     def send_messages(self, drone: DroneState, messages: List[bytes]) -> None:
         """Pack all messages into a single Wi-Fi beacon vendor-specific IE and send."""
         msg_count = bytes([len(messages) & 0xFF])
-        header = bytes([self.APP_CODE, self._counter]) + self.PACK_HEADER_PREFIX + msg_count
+        header = bytes([self.APP_CODE, self._counter]) + self.pack_header_prefix + msg_count
         self._counter = (self._counter + 1) & 0xFF
         vendor_data = header + b''.join(messages)
 


### PR DESCRIPTION
This PR refactors the Wi-Fi Transport Backend to be be fully compliant with ASTM F3411-22a and standard IEEE 802.11b/g protocols. 

Previously, spoofed Wi-Fi beacons were being dropped by strict mobile OS network stacks (like Android's Wi-Fi driver) and failed to broadcast frequently enough to be reliably detected. This PR resolves both the structural and timing requirements for Wi-Fi OpenDroneID spoofing.

### Key Changes

1. **Protocol Versioning (ASTM F3411-22a)**
   - Updated all OpenDroneID payloads to use Protocol Version 2 (`0xF2` / `0x12`), abandoning the legacy Version 0 format to ensure modern scanners recognize the packets.
   - Centralized message types into a `MsgType` `IntEnum` to improve code readability and remove magic numbers.

2. **Strict 802.11g Compliance & Channel Sync**
   - Added `--wifi-channel` (default: 6) to lock the physical hardware to the transmission channel using `iw dev <iface> set channel`.
   - Added the `DSset` Information Element to guarantee the beacon payload reflects the physical channel.
   - Appended mandatory 802.11g Information Elements (`TIM`, `ERPinfo`, `ESRates`) and split the basic `Rates` field to correctly mimic a fully compliant 802.11b/g Access Point. This prevents strict network stacks from silently discarding the frames as malformed.
   - Introduced the `--wifi-ess` flag to optionally broadcast the ESS capability, making the drone show up as an Infrastructure BSS if desired.

3. **Thread-Safe 10Hz Beacon Timing**
   - Implemented a dedicated background daemon thread (`_transmit_loop`) to handle Wi-Fi transmission independently of the main spoofer's kinematic update loop.
   - Exposed `--wifi-beacon-interval` (defaulting to `0.1024s`, exactly 100 Time Units) to blast out beacons at ~10Hz, satisfying ASTM F3411-22 interval requirements on non-social channels.
   - Eliminated a Scapy object race condition by caching static Information Elements and generating fresh 802.11 headers (`Sequence Control` and `timestamp`) locally within the thread, protected by a `threading.Lock`.

4. **Per-Transport MAC Address Generation**
   - Split `generate_random_mac()` into `generate_wifi_mac()` (unicast LAA, bit mask `0bxxxxxx10`) and `generate_ble_mac()` (Static Random per BT Core Spec §1.3.2, bit mask `0b11xxxxxx`), as the two protocols have different address requirements.
   - Added a dedicated `ble_address` field to `DroneState` so each drone carries independent, protocol-correct addresses. `wifi.py` uses `mac_address`; `ble.py` and `ble5_only.py` use `ble_address`.
   - Scenario JSON files can override each independently via `"mac"` and `"ble_mac"` drone fields.

### Testing
- Tested on Android with Drone Scanner and DroneTag apps; beacons are now reliably received.
- Tested `spoof_drones.py` CLI parser; scenario JSON configs fully parse the new `wifi` global arguments (`channel`, `ess`, `beacon_interval`).
```