### PR TITLE
Feature: BLE 5 Extended Advertising Support

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -20,7 +20,9 @@ Note that CLI flags override config values.
 - `transport` (string): `"wifi"`, `"ble"`, or `"both"`. Default: `"wifi"`.
 - `ble` (object): BLE-specific settings (optional).
   - `adapter` (string): HCI adapter name. Default: `"hci0"`.
-  - `advertising_interval_ms` (int): time per BLE advertisement in ms. Default: `200`.
+  - `advertising_interval_ms` (int): interval for BLE 4 legacy advertisements. Default: `200`.
+  - `extended_interval_ms` (int): pulse rate for BLE 5 extended pack. Default: same as `advertising_interval_ms`.
+  - `extended` (bool): enable BLE 5 Extended Advertising (Coded PHY). Default: `false`.
 - `wifi` (object): Wi-Fi-specific settings (optional).
   - `channel` (int): Wi-Fi channel for injection. Default: `6`.
   - `ess` (bool): Set ESS capability (make beacon look like an AP). Default: `false`.
@@ -72,12 +74,14 @@ Sends ASTM F3411-19 payloads inside Wi-Fi beacon frames with a vendor-specific
 IE (OUI 0xFA0BBC). Requires a Wi-Fi adapter in monitor mode. Note that many receivers will not parse those, specially phone applications don't do good with this method.
 
 ### `ble`
-Sends ASTM F3411-22 payloads as BLE `ADV_NONCONN_IND` advertisements with
-Service Data UUID 0xFFFA. Requires a Linux Bluetooth adapter (HCI) and root.
+Sends ASTM F3411-22 payloads as BLE advertisements with Service Data UUID 0xFFFA. 
+Requires a Linux Bluetooth adapter (HCI) and root.
 
-One message per advertisement — the tool rotates through message types, sending
-Location at 3x frequency. Multiple drones are time-multiplexed on the single
-radio. With 200ms per ad, ~5 drones fit in a 1-second cycle.
+**Legacy Mode (BLE 4)**: Uses `ADV_NONCONN_IND` packets. Since one legacy advertisement can only hold a single ASTM message, the tool **rotates** through a sequence (2x Location + 2x Statics) to transmit the full drone state. Each drone occupies the radio for `4 * advertising_interval_ms` (e.g., 800ms by default).
+
+**Extended Mode (BLE 5)**: Uses LE Coded PHY to transmit a full **ODID Message Pack** (containing all drone data) in a single advertisement. For maximum compatibility, the tool still maintains the Legacy rotation in the background while the Extended advertisement pulses.
+
+In this mode, `advertising_interval_ms` sets the interval for the legacy advertisements, while `extended_interval_ms` sets the interval for the extended advertisements.
 
 ### `both`
 Sends on Wi-Fi and BLE simultaneously.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ For full architecture details, see [ARCHITECTURE.md](ARCHITECTURE.md).
 | `-v` | `--verbose` | - | - | Enable debug logging |
 | `-t` | `--transport` | `wifi\|ble\|both` | config or `wifi` | Transport backend |
 | | `--ble-adapter` | `str` | config or `hci0` | BLE HCI adapter name |
+| | `--ble-interval` | `int` | `200` | BLE 4 legacy advertising interval (ms) |
+| | `--ble-extended-interval` | `int` | same as legacy | BLE 5 extended advertising interval (ms) |
+| | `--ble-extended` | - | - | Enable BLE 5 Extended Advertising (Coded PHY) |
 | | `--wifi-channel`| `int` | config or `6` | Wi-Fi channel for injection |
 | | `--wifi-ess`    | - | - | Set ESS capability (make beacon look like an AP) |
 | | `--wifi-beacon-interval` | `float` | config or `0.1024` | Wi-Fi beacon transmission interval in seconds |

--- a/drone_rid_spoofer/cli.py
+++ b/drone_rid_spoofer/cli.py
@@ -53,6 +53,12 @@ def parse_args() -> argparse.Namespace:
                         help="Transport backend (default: wifi)")
     parser.add_argument("--ble-adapter", type=str, default=None,
                         help="BLE adapter name (default: hci0). If BLE transport is used")
+    parser.add_argument("--ble-interval", type=int, default=None,
+                        help="Interval for BLE 4 legacy advertisements in ms (default: 200)")
+    parser.add_argument("--ble-extended-interval", type=int, default=None,
+                        help="Interval override for BLE 5 extended advertisements in ms (default: same as --ble-interval)")
+    parser.add_argument("--ble-extended", action="store_true", default=None,
+                        help="Enable BLE 5 Extended Advertising (Coded PHY) alongside legacy rotation")
     parser.add_argument("--wifi-ess", action="store_true", default=None,
                         help="Set the ESS capability bit on Wi-Fi beacons "
                              "(default: off; spoofed drone is not advertised as an AP)")
@@ -81,7 +87,9 @@ def load_config(path: str) -> dict:
 
 
 def create_backends(transport: str, interface: str, ble_adapter: str,
-                    ble_interval_ms: int, wifi_ess: bool = False,
+                    ble_interval: int, ble_extended_interval: int = None,
+                    ble_extended: bool = False,
+                    wifi_ess: bool = False,
                     wifi_channel: int = 6, wifi_beacon_interval: float = 0.1024) -> List[TransportBackend]:
     """Create transport backend instances based on configuration."""
     backends: List[TransportBackend] = []
@@ -91,8 +99,19 @@ def create_backends(transport: str, interface: str, ble_adapter: str,
         backends.append(WifiBackend(interface, ess=wifi_ess, channel=wifi_channel, beacon_interval=wifi_beacon_interval))
 
     if transport in ("ble", "both"):
-        from drone_rid_spoofer.transport.ble import BleBackend
-        backends.append(BleBackend(adapter=ble_adapter, advertising_interval_ms=ble_interval_ms))
+        if ble_extended:
+            from drone_rid_spoofer.transport.ble import BleExtendedBackend
+            backends.append(BleExtendedBackend(
+                adapter=ble_adapter,
+                legacy_interval_ms=ble_interval,
+                extended_interval_ms=ble_extended_interval
+            ))
+        else:
+            from drone_rid_spoofer.transport.ble import BleLegacyBackend
+            backends.append(BleLegacyBackend(
+                adapter=ble_adapter,
+                advertising_interval_ms=ble_interval,
+            ))
 
     return backends
 
@@ -127,12 +146,19 @@ def main() -> None:
         if args.transport is None:
             args.transport = config_global.get("transport", "wifi")
 
+        ble_config = config_global.get("ble", {})
         if args.ble_adapter is None:
-            ble_config = config_global.get("ble", {})
             args.ble_adapter = ble_config.get("adapter", "hci0")
-            ble_interval_ms = ble_config.get("advertising_interval_ms", 200)
-        else:
-            ble_interval_ms = 200
+        
+        if args.ble_interval is None:
+            args.ble_interval = ble_config.get("advertising_interval_ms", 200)
+            
+        if args.ble_extended_interval is None:
+            args.ble_extended_interval = ble_config.get("extended_interval_ms", args.ble_interval)
+
+        if args.ble_extended is None:
+            ble_config = config_global.get("ble", {})
+            args.ble_extended = bool(ble_config.get("extended", False))
 
         if args.wifi_ess is None:
             wifi_config = config_global.get("wifi", {})
@@ -155,7 +181,10 @@ def main() -> None:
         logging.info(f"Interval between packets(s): {args.interval}s")
 
         backends = create_backends(args.transport, args.interface, args.ble_adapter,
-                                   ble_interval_ms, wifi_ess=args.wifi_ess,
+                                   args.ble_interval, 
+                                   ble_extended_interval=args.ble_extended_interval,
+                                   ble_extended=args.ble_extended,
+                                   wifi_ess=args.wifi_ess,
                                    wifi_channel=args.wifi_channel,
                                    wifi_beacon_interval=args.wifi_beacon_interval)
         spoofer = DroneSpoofer(args, backends)

--- a/drone_rid_spoofer/spoofer.py
+++ b/drone_rid_spoofer/spoofer.py
@@ -69,18 +69,32 @@ class DroneSpoofer:
 
         try:
             tty.setcbreak(stdin_fd)
+            interval = self.args.interval
+            next_tick = time.time()
 
             while True:
+                now = time.time()
+
+                # 1. Check for keyboard input frequently (20Hz)
                 if self._has_keyboard_input():
                     key = sys.stdin.read(1)
                     self._process_movement_key(drone, key)
-
-                if datetime.now() >= next_send:
+                
+                # 2. Transmit at the configured interval
+                if now >= next_tick:
                     self._send(drone)
                     logger.info(f"Sent packet for {drone.serial.decode()}")
-                    next_send = datetime.now() + timedelta(seconds=self.args.interval)
+                    
+                    # Schedule next tick
+                    next_tick += interval
+                    # If we fell behind, skip ahead to avoid burst catch-up
+                    if next_tick < time.time():
+                        next_tick = time.time() + interval
 
-                time.sleep(self.args.interval)
+                # 3. Sleep until next tick or next input check (whichever is sooner)
+                sleep_time = min(0.05, next_tick - time.time())
+                if sleep_time > 0:
+                    time.sleep(sleep_time)
 
         except KeyboardInterrupt:
             logger.info("Manual mode stopped by user")
@@ -223,37 +237,56 @@ class DroneSpoofer:
         return {k: entry[k] for k in keys if k in entry}
 
     def _run_automatic_loop(self, drones: List[DroneState]) -> None:
-        next_send = datetime.now()
+        interval = float(self.args.interval)
+        next_tick = time.time()
         packet_batch_count = 0
 
         try:
             while True:
-                if datetime.now() >= next_send:
-                    now = datetime.now()
-                    for drone in drones:
-                        if drone.end_time and now >= drone.end_time:
-                            if drone.active:
-                                logger.info(f"Drone {drone.serial.decode()} expired; stopping transmission")
-                                drone.active = False
-                            continue
-                        if not drone.active:
-                            continue
-                        if drone.mode == "random":
-                            drone.update_location(10000)
-                            drone.drift_kinematics()
-                        elif drone.mode == "waypoints":
-                            self._update_waypoints(drone, now)
-                        self._send(drone)
-                        time.sleep(0.2)
+                active_count = 0
+                dt_now = datetime.now()
+                
+                # 1. Process all drones in this batch
+                for drone in drones:
+                    if drone.end_time and dt_now >= drone.end_time:
+                        if drone.active:
+                            logger.info(f"Drone {drone.serial.decode()} expired; stopping transmission")
+                            drone.active = False
+                        continue
+                    if not drone.active:
+                        continue
+                        
+                    active_count += 1
+                    if drone.mode == "random":
+                        drone.update_location(10000)
+                        drone.drift_kinematics()
+                    elif drone.mode == "waypoints":
+                        self._update_waypoints(drone, dt_now)
+                    
+                    self._send(drone)
 
-                    packet_batch_count += 1
-                    active_count = sum(1 for drone in drones if drone.active)
-                    logger.info(f"Sent batch {packet_batch_count} ({active_count} packets)")
-                    if active_count == 0:
-                        logger.info("All drones expired; stopping automatic mode")
-                        break
-                    next_send = datetime.now() + timedelta(seconds=self.args.interval)
-                time.sleep(self.args.interval)
+                packet_batch_count += 1
+                logger.info(f"Sent batch {packet_batch_count} ({active_count} active drones)")
+                
+                if active_count == 0 and any(d.end_time for d in drones):
+                    logger.info("All drones expired; stopping automatic mode")
+                    break
+                    
+                # 2. Advance deadline for next batch
+                next_tick += interval
+                
+                # 3. If the work took longer than the interval, slide the deadline forward
+                # to prevent a "catch-up" burst of packets.
+                now = time.time()
+                if next_tick < now:
+                    logger.warning(f"Batch processing took {now - (next_tick - interval):.2f}s, "
+                                   f"which is longer than interval {interval}s! Sliding deadline.")
+                    next_tick = now + interval
+
+                # 4. Compensating sleep until the next deadline
+                sleep_time = next_tick - time.time()
+                if sleep_time > 0:
+                    time.sleep(sleep_time)
 
         except KeyboardInterrupt:
             logger.info(f"Automatic mode stopped. Sent {packet_batch_count} batches total")

--- a/drone_rid_spoofer/transport/ble.py
+++ b/drone_rid_spoofer/transport/ble.py
@@ -1,24 +1,30 @@
 """BLE transport backend for ASTM F3411-22 Remote ID.
 
-Uses raw HCI sockets to send BLE ADV_NONCONN_IND advertisements.
-Requires Linux with root privileges (same as Wi-Fi monitor mode).
+Two backend classes for different hardware capabilities:
 
-BLE AD structure (31 bytes — legacy advertising limit):
-  Length:    1 byte  (0x1E = 30)
-  AD Type:  1 byte  (0x16 = Service Data - 16-bit UUID)
-  UUID:     2 bytes (0xFFFA little-endian → 0xFA 0xFF)
-  App Code: 1 byte  (0x0D for ASTM F3411)
-  Counter:  1 byte  (increments per advertisement)
-  Payload:  25 bytes (one ASTM message type)
+  BleLegacyBackend — BLE 4 legacy HCI API (0x2005–0x200A).
+    Uses ADV_NONCONN_IND with one 25-byte ASTM message per advertisement,
+    rotating through types with Location sent at 3x frequency.
+    Works on any BLE 4+ adapter.
 
-One message per advertisement — rotates through types with Location
-sent at higher frequency (3x).
+  BleExtendedBackend — BLE 5 Extended Advertising HCI API (0x2035–0x2039).
+    Handle 0: legacy PDU (properties=0x0010), 1M PHY — BLE 4 compat.
+              Sends one ASTM message per advertisement, rotating through
+              message types. Location is sent at 3x frequency for compliance.
+    Handle 1: extended PDU (properties=0x0000), LE Coded PHY — carries
+              a full ODID Message Pack with all messages in one shot.
+    Requires a BLE 5 capable adapter.
+
+Select via CLI: default is legacy, --ble-extended switches to extended.
+
+Requires Linux with root privileges.
 """
 
 import logging
 import select
 import socket
 import struct
+import subprocess
 import time
 from typing import Dict, List, Optional
 
@@ -28,12 +34,6 @@ from drone_rid_spoofer.transport.base import TransportBackend
 
 logger = logging.getLogger(__name__)
 
-# HCI command opcodes (OGF << 10 | OCF)
-HCI_CMD_LE_SET_ADV_PARAMS = 0x2006
-HCI_CMD_LE_SET_ADV_DATA = 0x2008
-HCI_CMD_LE_SET_ADV_ENABLE = 0x200A
-HCI_CMD_LE_SET_RANDOM_ADDR = 0x2005
-
 # HCI socket options (Linux)
 SOL_HCI = 0
 HCI_FILTER = 2
@@ -42,6 +42,23 @@ HCI_FILTER = 2
 HCI_EVENT_PKT = 0x04
 EVT_CMD_COMPLETE = 0x0E
 EVT_CMD_STATUS = 0x0F
+
+# BLE 4 Legacy HCI opcodes (BT Core §7.8.5–10)
+HCI_CMD_LE_SET_RANDOM_ADDR = 0x2005
+HCI_CMD_LE_SET_ADV_PARAMS = 0x2006
+HCI_CMD_LE_SET_ADV_DATA = 0x2008
+HCI_CMD_LE_SET_ADV_ENABLE = 0x200A
+
+# BLE 5 Extended Advertising HCI opcodes (BT Core §7.8.52–56)
+HCI_CMD_LE_SET_EXT_RANDOM_ADDR = 0x2035
+HCI_CMD_LE_SET_EXT_ADV_PARAMS = 0x2036
+HCI_CMD_LE_SET_EXT_ADV_DATA = 0x2037
+HCI_CMD_LE_SET_EXT_ADV_ENABLE = 0x2039
+
+# BLE RID constants
+ASTM_UUID = b'\xFA\xFF'  # 0xFFFA little-endian
+ASTM_APP_CODE = 0x0D
+AD_TYPE_SERVICE_DATA_16 = 0x16
 
 
 def _build_event_filter() -> bytes:
@@ -55,12 +72,7 @@ def _build_event_filter() -> bytes:
     event_mask_hi = 0xFFFFFFFF
     return struct.pack("<IIIH", type_mask, event_mask_lo, event_mask_hi, 0) + b'\x00\x00'
 
-# BLE RID constants
-ASTM_UUID = b'\xFA\xFF'  # 0xFFFA little-endian
-ASTM_APP_CODE = 0x0D
-AD_TYPE_SERVICE_DATA_16 = 0x16
 
-# Location message type is 1 (upper 4 bits)
 def _mac_to_bytes(mac: str) -> bytes:
     """Convert MAC address string to 6 bytes (reverse order for HCI)."""
     parts = mac.split(':')
@@ -73,34 +85,37 @@ def _build_hci_command(opcode: int, data: bytes) -> bytes:
     return struct.pack('<BHB', 0x01, opcode, len(data)) + data
 
 
-class BleBackend(TransportBackend):
-    """BLE advertisement transport for ASTM F3411-22 RID.
+# ── Shared base class ─────────────────────────────────────────────────────────
 
-    Sends one ASTM message per BLE advertisement, rotating through
-    message types. Location is sent at 3x frequency for compliance.
+class _BleBase(TransportBackend):
+    """Shared HCI plumbing for BLE backends.
 
-    Multi-drone constraint: BLE has one radio, so drones are
-    time-multiplexed. Each cycle emits 3x Location plus one rotating
-    static message (BasicID, Self-ID, System, OperatorID), i.e. 4 ads
-    per drone. At 200ms per ad and a 1s interval, two drones fit per
-    cycle; reduce advertising_interval_ms (e.g. 100) to fit more.
+    Handles socket setup, HCI command/event processing, and the ASTM
+    message rotation sequence. Subclasses implement the actual advertising
+    parameter/data/enable commands for their HCI API version.
     """
 
-    def __init__(self, adapter: str = "hci0", advertising_interval_ms: int = 200):
+    # Subclasses set this so 0x0C "Command Disallowed" on enable/disable
+    # is logged at debug level (benign) instead of warning.
+    _ADV_ENABLE_OPCODES: tuple = ()
+
+    def __init__(self, adapter: str = "hci0", advertising_interval_ms: int = 200,
+                 protocol_version: int = 2):
         self.adapter = adapter
         self.adapter_id = int(adapter.replace("hci", ""))
         self.advertising_interval_ms = advertising_interval_ms
+        self.protocol_version = protocol_version
+        # Message pack header: msg_type (0xF = Pack) + ver, msg_size (0x19 = 25 bytes)
+        self.pack_header_prefix = bytes([(MsgType.PACK << 4) | self.protocol_version, 0x19])
         self._sock: Optional[socket.socket] = None
         self._counters: Dict[bytes, int] = {}  # per-drone message counter
         self._static_index: Dict[bytes, int] = {}  # per-drone static-msg rotation pointer
-        self._adv_enabled: bool = False  # tracked controller state; avoids redundant ENABLE/DISABLE
         self._open_socket()
+        self._init_advertising()
 
     def _open_socket(self) -> None:
         """Open raw HCI socket and ensure the adapter is up."""
         try:
-            # Bring the adapter up (equivalent to `hciconfig hci0 up`)
-            import subprocess
             subprocess.run(
                 ["hciconfig", self.adapter, "up"],
                 check=True, capture_output=True,
@@ -178,9 +193,9 @@ class BleBackend(TransportBackend):
             if evt_opcode != opcode:
                 continue
             if status != 0:
-                # 0x0C "Command Disallowed" on LE_SET_ADV_ENABLE just means
-                # advertising was already in the requested state — benign.
-                if (opcode == HCI_CMD_LE_SET_ADV_ENABLE and status == 0x0C):
+                # 0x0C "Command Disallowed" on advertising enable/disable just
+                # means advertising was already in the requested state — benign.
+                if opcode in self._ADV_ENABLE_OPCODES and status == 0x0C:
                     logger.debug(
                         f"HCI cmd 0x{opcode:04x} no-op: status=0x{status:02x}"
                     )
@@ -189,6 +204,102 @@ class BleBackend(TransportBackend):
                         f"HCI cmd 0x{opcode:04x} failed: status=0x{status:02x}"
                     )
             return
+
+    def _warn_if_bad_random_address(self, mac: str, addr_bytes: bytes) -> None:
+        """Log a warning if MAC doesn't satisfy BLE Static Random Address format."""
+        if addr_bytes[-1] & 0xC0 != 0xC0:
+            logger.warning(
+                f"BLE address {mac} does not have top 2 bits set — "
+                f"not a valid BLE Static Random Address (BT Core Vol 6, Part B §1.3.2)"
+            )
+
+    def _build_send_sequence(self, drone_key: bytes,
+                             messages: List[bytes]) -> List[bytes]:
+        """Return per-cycle send sequence: 2x Location + 2 rotating static msgs.
+
+        ASTM F3411-22a Timing Requirements:
+          - Location/Vector: 1 Hz (at least once per second)
+          - Other messages: 0.33 Hz (at least once every 3 seconds)
+
+        With up to 4 static types (BasicID, SelfID, System, OperatorID),
+        sending 2 rotating statics per cycle ensures a full refresh every
+        2 seconds, satisfying the 3s requirement.
+        """
+        location_msgs = [m for m in messages if m and (m[0] >> 4) == MsgType.LOCATION]
+        static_msgs = [m for m in messages if m and (m[0] >> 4) != MsgType.LOCATION]
+
+        # Send location twice (if available)
+        sequence = (location_msgs[:1] * 2) if location_msgs else []
+
+        if static_msgs:
+            idx = self._static_index.get(drone_key, 0)
+            # Send 2 rotating statics
+            for _ in range(min(2, len(static_msgs))):
+                sequence.append(static_msgs[idx % len(static_msgs)])
+                idx += 1
+            self._static_index[drone_key] = idx % len(static_msgs)
+        return sequence
+
+    def _build_legacy_ad(self, message: bytes, counter: int) -> bytes:
+        """Build a 31-byte legacy AD element for a single ASTM message."""
+        return bytes([
+            30,  # length of remaining AD data
+            AD_TYPE_SERVICE_DATA_16,
+        ]) + ASTM_UUID + bytes([
+            ASTM_APP_CODE,
+            counter & 0xFF,
+        ]) + message
+
+    def _init_advertising(self) -> None:
+        """Subclasses configure their advertising sets here."""
+        raise NotImplementedError
+
+    def _disable_advertising(self) -> None:
+        """Subclasses disable their advertising here."""
+        raise NotImplementedError
+
+    def close(self) -> None:
+        """Disable advertising and close HCI socket."""
+        if self._sock:
+            try:
+                self._disable_advertising()
+            except OSError:
+                pass
+            self._sock.close()
+            self._sock = None
+            logger.info("BLE backend: closed HCI socket")
+
+
+# ── BLE 4 Legacy backend ──────────────────────────────────────────────────────
+
+class BleLegacyBackend(_BleBase):
+    """BLE 4 Legacy Advertising transport for ASTM F3411-19/22 RID.
+
+    Sends one ASTM message per BLE advertisement, rotating through
+    message types (2x Location + 2x rotating Statics per cycle).
+    Used for hardware that does not support BLE 5 Extended Advertising.
+    Works on any BLE 4+ adapter.
+
+    Multi-drone constraint: BLE has one radio, so drones are
+    time-multiplexed. Each cycle emits 3x Location plus one rotating
+    static message (BasicID, Self-ID, System, OperatorID), i.e. 4 ads
+    per drone. At 200ms per ad and a 1s interval, two drones fit per
+    cycle; reduce advertising_interval_ms (e.g. 100) to fit more.
+    """
+
+    _ADV_ENABLE_OPCODES = (HCI_CMD_LE_SET_ADV_ENABLE,)
+
+    def __init__(self, adapter: str = "hci0", advertising_interval_ms: int = 200,
+                 protocol_version: int = 2):
+        self._adv_enabled: bool = False
+        super().__init__(adapter, advertising_interval_ms, protocol_version)
+
+    def _init_advertising(self) -> None:
+        """No-op — legacy params are set each cycle in send_messages."""
+        pass
+
+    def _disable_advertising(self) -> None:
+        self._set_advertising_enable(False)
 
     def _set_advertising_enable(self, enable: bool) -> None:
         """Enable or disable BLE advertising. No-op when already in that state."""
@@ -200,11 +311,12 @@ class BleBackend(TransportBackend):
     def _set_random_address(self, mac: str) -> None:
         """Set the random advertising address."""
         addr_bytes = _mac_to_bytes(mac)
+        self._warn_if_bad_random_address(mac, addr_bytes)
         self._send_hci_command(HCI_CMD_LE_SET_RANDOM_ADDR, addr_bytes)
 
     def _set_advertising_params(self) -> None:
         """Set advertising parameters for ADV_NONCONN_IND."""
-        # Interval in units of 0.625ms
+        # Interval is in units of 0.625 ms
         interval = int(self.advertising_interval_ms / 0.625)
         params = struct.pack('<HH', interval, interval)  # min, max interval
         params += bytes([
@@ -220,39 +332,11 @@ class BleBackend(TransportBackend):
         self._send_hci_command(HCI_CMD_LE_SET_ADV_PARAMS, params)
 
     def _set_advertising_data(self, message: bytes, counter: int) -> None:
-        """Set the advertising data payload (31 bytes max).
-
-        AD structure:
-          [length=30][AD type=0x16][UUID 0xFFFA LE][app=0x0D][counter][25-byte payload]
-        """
-        ad_data = bytes([
-            30,  # length of remaining AD data
-            AD_TYPE_SERVICE_DATA_16,
-        ]) + ASTM_UUID + bytes([
-            ASTM_APP_CODE,
-            counter & 0xFF,
-        ]) + message
-
+        """Set the advertising data payload (31 bytes max)."""
+        ad_data = self._build_legacy_ad(message, counter)
         # HCI LE Set Advertising Data: length(1) + data(31)
         hci_data = bytes([len(ad_data)]) + ad_data + b'\x00' * (31 - len(ad_data))
         self._send_hci_command(HCI_CMD_LE_SET_ADV_DATA, hci_data)
-
-    def _build_send_sequence(self, drone_key: bytes,
-                             messages: List[bytes]) -> List[bytes]:
-        """Return per-cycle send sequence: 3x Location + 1 rotating static msg.
-
-        Static messages (BasicID, Self-ID, System, OperatorID) rotate one per
-        cycle so each is refreshed every N cycles, where N = number of statics.
-        """
-        location_msgs = [m for m in messages if m and (m[0] >> 4) == MsgType.LOCATION]
-        static_msgs = [m for m in messages if m and (m[0] >> 4) != MsgType.LOCATION]
-
-        sequence = location_msgs * 3
-        if static_msgs:
-            idx = self._static_index.get(drone_key, 0) % len(static_msgs)
-            sequence.append(static_msgs[idx])
-            self._static_index[drone_key] = (idx + 1) % len(static_msgs)
-        return sequence
 
     def send_messages(self, drone: DroneState, messages: List[bytes]) -> None:
         """Send ASTM messages as individual BLE advertisements.
@@ -290,13 +374,160 @@ class BleBackend(TransportBackend):
 
         self._counters[drone_key] = counter
 
-    def close(self) -> None:
-        """Disable advertising and close HCI socket."""
-        if self._sock:
-            try:
-                self._set_advertising_enable(False)
-            except OSError:
-                pass
-            self._sock.close()
-            self._sock = None
-            logger.info("BLE backend: closed HCI socket")
+
+# ── BLE 5 Extended Advertising backend ─────────────────────────────────────────
+
+class BleExtendedBackend(_BleBase):
+    """BLE 5 Extended Advertising transport for ASTM F3411-22 RID.
+
+    Uses BLE 5 Extended Advertising with two simultaneous handles:
+      Handle 0: Legacy PDU (1M PHY) — BLE 4 compatible single-message rotation.
+                Used for backward compatibility with standard RID scanners.
+      Handle 1: Extended PDU (LE Coded PHY) — Full ODID Message Pack.
+                Maximizes range and ensures all messages are received at once.
+
+    Timing Model:
+      The handles are decoupled. The Legacy PDU rotates through the message
+      sequence with a fast 'legacy_interval_ms', while the Extended PDU pulses
+      in the background at a slower 'extended_interval_ms'.
+    """
+
+    _ADV_ENABLE_OPCODES = (HCI_CMD_LE_SET_EXT_ADV_ENABLE,)
+
+    def __init__(self, adapter: str = "hci0",
+                 legacy_interval_ms: int = 100,
+                 extended_interval_ms: int = 200,
+                 protocol_version: int = 2):
+        super().__init__(adapter, extended_interval_ms, protocol_version)
+        self.legacy_interval_ms = legacy_interval_ms
+
+    def _init_advertising(self) -> None:
+        """Initialize extended advertising sets."""
+        self._set_advertising_enable(False, [0x00, 0x01])
+        # Handle 0: legacy PDU, 1M PHY — SID 0
+        self._set_advertising_params(0x00, 0x0010, 0x01, 0x01, 0x00)
+        # Handle 1: extended PDU, LE Coded PHY — SID 1
+        self._set_advertising_params(0x01, 0x0000, 0x03, 0x03, 0x01)
+
+    def _disable_advertising(self) -> None:
+        self._set_advertising_enable(False, [])
+
+    def _set_advertising_params(self, handle: int, properties: int,
+                                 primary_phy: int, secondary_phy: int, sid: int,
+                                 interval_ms: Optional[int] = None) -> None:
+        """Set Extended Advertising Parameters for the given handle."""
+        # Use provided override or the backend's default interval
+        ival = interval_ms if interval_ms is not None else self.advertising_interval_ms
+        # Interval is in units of 0.625 ms
+        interval = int(ival / 0.625)
+        interval_bytes = interval.to_bytes(3, byteorder='little')
+        params = struct.pack("<BH", handle, properties)
+        params += interval_bytes  # Min interval (24-bit)
+        params += interval_bytes  # Max interval (24-bit)
+        params += bytes([
+            0x07,  # Primary Channel Map (37, 38, 39)
+            0x01,  # Own address type (Random)
+            0x00,  # Peer address type
+        ])
+        params += b'\x00' * 6  # Peer address
+        params += bytes([
+            0x00,  # Filter policy
+            0x7F,  # Tx power (Host has no preference)
+            primary_phy,
+            0x00,  # Secondary Max Skip
+            secondary_phy,
+            sid & 0x0F,  # Advertising SID (must be unique for sets sharing an address)
+            0x00,  # Scan Request Notification Enable
+        ])
+        self._send_hci_command(HCI_CMD_LE_SET_EXT_ADV_PARAMS, params)
+
+    def _set_random_address(self, handle: int, mac: str) -> None:
+        """Set the random MAC address for the given advertising handle."""
+        addr_bytes = _mac_to_bytes(mac)
+        self._warn_if_bad_random_address(mac, addr_bytes)
+        payload = struct.pack("<B", handle) + addr_bytes
+        self._send_hci_command(HCI_CMD_LE_SET_EXT_RANDOM_ADDR, payload)
+
+    def _set_advertising_data(self, handle: int, ad_payload: bytes) -> None:
+        """Set Extended Advertising Data for the given handle."""
+        # Handle(1), Op=0x03(Complete), Frag=0x01(No Frag), Length(1), Data
+        header = struct.pack("<BBBB", handle, 0x03, 0x01, len(ad_payload))
+        self._send_hci_command(HCI_CMD_LE_SET_EXT_ADV_DATA, header + ad_payload)
+
+    def _set_advertising_enable(self, enable: bool, handles: List[int]) -> None:
+        """Enable or disable Extended Advertising for the given handles."""
+        if enable:
+            payload = struct.pack("<BB", 0x01, len(handles))
+            for h in handles:
+                payload += struct.pack("<BHB", h, 0x0000, 0x00)
+        else:
+            # Explicitly disable specific handles if provided, otherwise try global disable
+            num_sets = len(handles)
+            payload = struct.pack("<BB", 0x00, num_sets)
+            for h in handles:
+                payload += struct.pack("<BHB", h, 0x0000, 0x00)
+        self._send_hci_command(HCI_CMD_LE_SET_EXT_ADV_ENABLE, payload)
+
+    def _build_message_pack_ad(self, messages: List[bytes], counter: int) -> bytes:
+        """Build a Service Data AD element containing an ODID Message Pack.
+
+        Layout: [AD Len][0x16][UUID][AppCode][Counter][PackHdr][MsgSize][N][msg0...msgN]
+        """
+        msg_count = len(messages) & 0xFF
+        service_data = (
+            ASTM_UUID
+            + bytes([ASTM_APP_CODE, counter & 0xFF])
+            + self.pack_header_prefix
+            + bytes([msg_count])
+            + b''.join(messages)
+        )
+        ad_length = 1 + len(service_data)  # AD Type byte + data
+        return bytes([ad_length, AD_TYPE_SERVICE_DATA_16]) + service_data
+
+    def send_messages(self, drone: DroneState, messages: List[bytes]) -> None:
+        """Send ASTM messages via BLE Extended Advertising.
+
+        Handle 0: legacy PDU — single message rotation (3x Location + 1 static).
+        Handle 1: extended PDU — full ODID Message Pack on LE Coded PHY.
+        """
+        if not self._sock:
+            logger.error("BLE socket not open")
+            return
+
+        drone_key = drone.serial
+        counter = self._counters.get(drone_key, 0)
+
+        # 1. Disable broadcasting before altering sets
+        self._set_advertising_enable(False, [0x00, 0x01])
+        time.sleep(0.01)
+
+        # 2. Re-apply Params and Address
+        # Use a faster dwell for Legacy rotation; use standard interval for Extended pack.
+        self._set_advertising_params(0x00, 0x0010, 0x01, 0x01, 0x00, interval_ms=self.legacy_interval_ms)
+        self._set_advertising_params(0x01, 0x0000, 0x03, 0x03, 0x01, interval_ms=self.advertising_interval_ms)
+        self._set_random_address(0x00, drone.ble_address)
+        self._set_random_address(0x01, drone.ble_address)
+
+        # BLE4 rotation sequence for handle 0
+        send_sequence = self._build_send_sequence(drone_key, messages)
+        
+        # 3. Upload and start the Message Pack (Handle 1)
+        pack_ad = self._build_message_pack_ad(messages, counter)
+        self._set_advertising_data(0x01, pack_ad)
+        self._set_advertising_enable(True, [0x01])
+
+        # 4. Manually cycle through Legacy messages (Handle 0)
+        for msg in send_sequence:
+            legacy_ad = self._build_legacy_ad(msg, counter)
+            self._set_advertising_data(0x00, legacy_ad)
+            self._set_advertising_enable(True, [0x00])
+
+            # Wait for the legacy dwell time
+            time.sleep(self.legacy_interval_ms / 1000.0)
+
+            self._set_advertising_enable(False, [0x00])
+            counter = (counter + 1) & 0xFF
+
+        # 5. Stop Handle 1
+        self._set_advertising_enable(False, [0x01])
+        self._counters[drone_key] = counter

--- a/scenario.template.json
+++ b/scenario.template.json
@@ -8,7 +8,7 @@
     "ble": {
       "adapter": "hci0",
       "advertising_interval_ms": 200,
-      "extended_interval_ms": 200,
+      "extended_interval_ms": 800,
       "extended": false
     }
   },

--- a/scenario.template.json
+++ b/scenario.template.json
@@ -7,7 +7,9 @@
     "transport": "wifi",
     "ble": {
       "adapter": "hci0",
-      "advertising_interval_ms": 200
+      "advertising_interval_ms": 200,
+      "extended_interval_ms": 200,
+      "extended": false
     }
   },
   "drones": [


### PR DESCRIPTION
# Description
This Pull Request introduces BLE 5 Extended Advertising support (LE Coded PHY) with dual-mode operations and refactors the spoofer's main transmission loop to use deadline-based scheduling for accurate packet intervals.

## Key Changes
1. BLE 5 Extended Advertising (Dual-Mode Support)
Decoupled Advertising Interfaces:
Handle 0 (Legacy BLE 4): Rotates through single ASTM F3411-22a messages (2x Location + 2x Statics sequence) to satisfy backwards compatibility. Uses standard ADV_NONCONN_IND advertisements.
Handle 1 (Extended BLE 5): Broadcasts a full ODID Message Pack containing all drone data in a single transmission burst via LE Coded PHY.
Independent Intervals:
--ble-interval sets the legacy rotation interval (ms).
--ble-extended-interval sets the extended message pack interval (ms).
Implemented alongside BLE4 legacy advertising to support older non BT5 senders.
2. Spoofer Loop Refactoring (Deadline-Based Timing)
Drift Elimination: Replaced fixed time.sleep(interval) calls with a deadline-compensating sleep. The spoofer now tracks an absolute timestamp next_tick and calculates exactly how long to sleep by subtracting the current execution time.
Removal of Hardcoded Sleeps: Eliminated the static 0.2s per-drone delays which caused cumulative drifts when running multiple spoofed targets.
Dual-Rate Manual Loop: The manual keyboard loop now polls for inputs at a responsive 20Hz (50ms) while sending packet updates at the user's specified transmission interval.

Checked HCI traffic via btmon to verify that both Handle 0 and Handle 1 allocate advertising parameters correctly, and that packets are scheduled at the configured intervals.
Checked that both Legacy and Extended Advertising still works.
